### PR TITLE
refactor: migrate lucide-react icon aliases to canonical names

### DIFF
--- a/src/renderer/src/components/ErrorBoundary.tsx
+++ b/src/renderer/src/components/ErrorBoundary.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Component, ReactNode } from 'react'
-import { AlertTriangle, RotateCcw } from 'lucide-react'
+import { TriangleAlert, RotateCcw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { createLogger } from '@/logger'
 
@@ -39,7 +39,7 @@ export class ErrorBoundary extends Component<Props, State> {
     if (this.state.hasError) {
       return (
         <div className="flex flex-col items-center justify-center h-screen bg-background-secondary text-foreground p-8">
-          <AlertTriangle className="h-16 w-16 text-red-500 mb-4" aria-hidden="true" />
+          <TriangleAlert className="h-16 w-16 text-red-500 mb-4" aria-hidden="true" />
           <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
           <p className="text-muted-foreground mb-4 text-center max-w-md">
             The application encountered an unexpected error. Try reloading to recover.

--- a/src/renderer/src/components/bookmarks/FolderTree.tsx
+++ b/src/renderer/src/components/bookmarks/FolderTree.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState, useRef, useEffect } from 'react'
-import { ChevronRight, ChevronDown, Folder, FolderOpen, Edit2, Trash2 } from 'lucide-react'
+import { ChevronRight, ChevronDown, Folder, FolderOpen, Pen, Trash2 } from 'lucide-react'
 import { useBookmarksStore, BookmarkFolder } from '@/stores/bookmarks'
 import { cn } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
@@ -123,7 +123,7 @@ export function FolderTree({ selectedFolderId, onSelectFolder, onEditFolder }: F
                 className="p-1 hover:bg-surface-active rounded transition-colors"
                 title="Rename folder"
               >
-                <Edit2 className="w-3.5 h-3.5" />
+                <Pen className="w-3.5 h-3.5" />
               </button>
               <button
                 onClick={(e) => handleDeleteFolder(e, folder)}

--- a/src/renderer/src/components/browser/AddressBar.tsx
+++ b/src/renderer/src/components/browser/AddressBar.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState, useEffect, FormEvent, useRef, useMemo, memo, useCallback } from 'react'
-import { Lock, Star, Loader2, Clock, History } from 'lucide-react'
+import { Lock, Star, LoaderCircle, Clock, History } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { useBrowserStore } from '@/stores/browser'
@@ -186,7 +186,7 @@ export const AddressBar = memo(function AddressBar() {
           ) : (
             <div className="absolute left-3 top-1/2 -translate-y-1/2 z-10" aria-hidden="true">
               {isLoading ? (
-                <Loader2 className="h-4 w-4 text-muted-foreground animate-spin" />
+                <LoaderCircle className="h-4 w-4 text-muted-foreground animate-spin" />
               ) : (
                 <img src={tonIcon} alt="" className="h-4 w-4" />
               )}

--- a/src/renderer/src/components/browser/NavigationButtons.tsx
+++ b/src/renderer/src/components/browser/NavigationButtons.tsx
@@ -3,7 +3,7 @@
  * Back, forward, reload, home, and stop.
  */
 
-import { ArrowLeft, ArrowRight, RotateCw, Home, X } from 'lucide-react'
+import { ArrowLeft, ArrowRight, RotateCw, House, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useBrowserStore } from '@/stores/browser'
 import { useTabsStore } from '@/stores/tabs'
@@ -82,7 +82,7 @@ export function NavigationButtons() {
         title={t('navigation.home')}
         aria-label={t('navigation.goHomeAria')}
       >
-        <Home className="h-4 w-4" aria-hidden="true" />
+        <House className="h-4 w-4" aria-hidden="true" />
       </Button>
     </nav>
   )

--- a/src/renderer/src/components/browser/StatusBar.tsx
+++ b/src/renderer/src/components/browser/StatusBar.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState, memo } from 'react'
 import { createLogger } from '@/logger'
 
 const log = createLogger('status')
-import { Wifi, WifiOff, Loader2, ArrowDown, ArrowUp } from 'lucide-react'
+import { Wifi, WifiOff, LoaderCircle, ArrowDown, ArrowUp } from 'lucide-react'
 import { useBrowserStore } from '@/stores/browser'
 import { APP_VERSION } from '@shared/constants'
 import type { StorageBag } from '@shared/types'
@@ -87,7 +87,7 @@ export const StatusBar = memo(function StatusBar() {
     if (proxySyncing) {
       return (
         <>
-          <Loader2 className="h-3 w-3 text-warning animate-spin" aria-hidden="true" />
+          <LoaderCircle className="h-3 w-3 text-warning animate-spin" aria-hidden="true" />
           <span className="text-warning">
             {anonymousMode ? t('statusBar.syncingMultiHop') : t('statusBar.syncing')}
           </span>

--- a/src/renderer/src/components/settings/sections/AboutSection.tsx
+++ b/src/renderer/src/components/settings/sections/AboutSection.tsx
@@ -3,7 +3,7 @@
  */
 
 import { memo, useState, useEffect, useCallback, useRef } from 'react'
-import { ExternalLink, CheckCircle, Download, RefreshCw, Loader2, AlertCircle } from 'lucide-react'
+import { ExternalLink, CircleCheckBig, Download, RefreshCw, LoaderCircle, CircleAlert } from 'lucide-react'
 import { SectionHeader } from '../shared/SectionHeader'
 import { APP_NAME, APP_VERSION } from '@shared/constants'
 import tonLogo from '@/assets/ton.png'
@@ -114,7 +114,7 @@ export const AboutSection = memo(function AboutSection() {
             disabled
             className="flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-all duration-200 bg-primary/15 border border-primary/30 text-primary opacity-70"
           >
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <LoaderCircle className="h-4 w-4 animate-spin" />
             {t('about.update.checking')}
           </button>
         )
@@ -125,7 +125,7 @@ export const AboutSection = memo(function AboutSection() {
             disabled
             className="flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-all duration-200 bg-green-500/15 border border-green-500/30 text-green-400"
           >
-            <CheckCircle className="h-4 w-4" />
+            <CircleCheckBig className="h-4 w-4" />
             {t('about.update.upToDate')}
           </button>
         )
@@ -152,7 +152,7 @@ export const AboutSection = memo(function AboutSection() {
             disabled
             className="flex items-center gap-1.5 px-4 py-1.5 rounded-full text-sm font-medium transition-all duration-200 bg-primary/15 border border-primary/30 text-primary opacity-70"
           >
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <LoaderCircle className="h-4 w-4 animate-spin" />
             {t('about.update.downloading')} {downloadPercent}%
           </button>
         )
@@ -172,7 +172,7 @@ export const AboutSection = memo(function AboutSection() {
         return (
           <div className="flex items-center gap-3">
             <span className="text-sm text-destructive flex items-center gap-1">
-              <AlertCircle className="h-3.5 w-3.5" />
+              <CircleAlert className="h-3.5 w-3.5" />
               {errorMessage || t('about.update.errorGeneric')}
             </span>
             <button

--- a/src/renderer/src/components/settings/sections/BookmarksSection.tsx
+++ b/src/renderer/src/components/settings/sections/BookmarksSection.tsx
@@ -3,7 +3,7 @@
  */
 
 import { memo, useState, useMemo, useRef, useEffect } from 'react'
-import { ExternalLink, RotateCcw, Search, Plus, Edit, Trash2, Globe } from 'lucide-react'
+import { ExternalLink, RotateCcw, Search, Plus, SquarePen, Trash2, Globe } from 'lucide-react'
 import { SectionHeader } from '../shared/SectionHeader'
 import { SettingRow } from '../shared/SettingRow'
 import { FolderTree } from '@/components/bookmarks/FolderTree'
@@ -255,7 +255,7 @@ export const BookmarksSection = memo(function BookmarksSection({
                         className="p-2 hover:bg-surface-active rounded transition-colors"
                         title={t('bookmarks.edit')}
                       >
-                        <Edit className="w-4 h-4 text-foreground" />
+                        <SquarePen className="w-4 h-4 text-foreground" />
                       </button>
                       <button
                         onClick={() => handleDelete(bookmark.id)}

--- a/src/renderer/src/components/settings/sections/PrivacySection.tsx
+++ b/src/renderer/src/components/settings/sections/PrivacySection.tsx
@@ -3,7 +3,7 @@
  */
 
 import { memo } from 'react'
-import { Trash2, CheckCircle } from 'lucide-react'
+import { Trash2, CircleCheckBig } from 'lucide-react'
 import { SectionHeader } from '../shared/SectionHeader'
 import { SettingRow } from '../shared/SettingRow'
 import { Toggle } from '../shared/Toggle'
@@ -39,7 +39,7 @@ export const PrivacySection = memo(function PrivacySection({
               t('privacy.clearing')
             ) : cleared ? (
               <>
-                <CheckCircle className="h-4 w-4" /> {t('privacy.done')}
+                <CircleCheckBig className="h-4 w-4" /> {t('privacy.done')}
               </>
             ) : (
               <>

--- a/src/renderer/src/components/theme-editor/ImportExportDialog.tsx
+++ b/src/renderer/src/components/theme-editor/ImportExportDialog.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState } from 'react'
-import { X, Upload, Download, AlertCircle, Check } from 'lucide-react'
+import { X, Upload, Download, CircleAlert, Check } from 'lucide-react'
 
 interface ImportDialogProps {
   onImport: (json: string) => boolean
@@ -99,7 +99,7 @@ export function ImportDialog({ onImport, onClose }: ImportDialogProps) {
           {/* Error message */}
           {error && (
             <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
-              <AlertCircle className="w-4 h-4 flex-shrink-0" />
+              <CircleAlert className="w-4 h-4 flex-shrink-0" />
               {error}
             </div>
           )}

--- a/src/renderer/src/components/theme-editor/ThemeList.tsx
+++ b/src/renderer/src/components/theme-editor/ThemeList.tsx
@@ -2,7 +2,7 @@
  * List of custom themes with actions.
  */
 
-import { Pencil, Trash2, Copy, Download, Check, AlertTriangle } from 'lucide-react'
+import { Pencil, Trash2, Copy, Download, Check, TriangleAlert } from 'lucide-react'
 import type { CustomTheme } from '@shared/types'
 import { hslToHex } from '../../lib/theme-utils'
 
@@ -116,7 +116,7 @@ export function ThemeList({
                 }`}
                 title={pendingDeleteId === theme.id ? 'Click again to confirm' : 'Delete theme'}
               >
-                {pendingDeleteId === theme.id ? <AlertTriangle className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
+                {pendingDeleteId === theme.id ? <TriangleAlert className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Rename 7 deprecated lucide-react icon aliases to their canonical names
- Prepares for lucide-react v1.0 where aliases may be removed
- `Filter → Funnel` deferred (requires lucide-react ≥0.483, will land after PR #16)

| Old (alias) | New (canonical) | Files |
|-------------|-----------------|-------|
| `AlertTriangle` | `TriangleAlert` | ErrorBoundary, ThemeList |
| `AlertCircle` | `CircleAlert` | ImportExportDialog, AboutSection |
| `CheckCircle` | `CircleCheckBig` | AboutSection, PrivacySection |
| `Loader2` | `LoaderCircle` | AddressBar, StatusBar, AboutSection |
| `Home` | `House` | NavigationButtons |
| `Edit` | `SquarePen` | BookmarksSection |
| `Edit2` | `Pen` | FolderTree |

## Test plan
- [x] Type-check passes
- [x] Lint passes (0 errors)
- [x] 370/370 tests pass
- [x] Icons are visually identical (same SVG, just canonical export name)