### PR TITLE
fix(security): resolve 8 must-have issues from deep scan

### DIFF
--- a/src/main/history/manager.ts
+++ b/src/main/history/manager.ts
@@ -24,10 +24,22 @@ export class HistoryManager extends EventEmitter {
   private mode: HistoryMode = HistoryMode.MEMORY
   private storage: SafeStorageWrapper | null = null
   private readyPromise: Promise<void>
+  private isReady: boolean = false
+  private pendingEntries: Array<{ url: string; title: string; favicon?: string }> = []
 
   constructor() {
     super()
-    this.readyPromise = this.loadSettings()
+    this.readyPromise = this.loadSettings().then(() => {
+      this.isReady = true
+      // Flush buffered entries that arrived before initialization completed
+      if (this.pendingEntries.length > 0) {
+        log.debug(`Flushing ${this.pendingEntries.length} buffered history entries`)
+        for (const entry of this.pendingEntries) {
+          this.addEntry(entry.url, entry.title, entry.favicon)
+        }
+        this.pendingEntries = []
+      }
+    })
   }
 
   async ready(): Promise<void> {
@@ -110,6 +122,13 @@ export class HistoryManager extends EventEmitter {
    * Add entry to history
    */
   addEntry(url: string, title: string, favicon?: string): void {
+    // Buffer entry if manager not yet ready (readyPromise not resolved)
+    if (!this.isReady) {
+      log.debug(`HistoryManager not ready, buffering entry: ${url}`)
+      this.pendingEntries.push({ url, title, favicon })
+      return
+    }
+
     // Don't record internal pages
     if (url.startsWith('ton://') || url.startsWith('about:') || url.startsWith('data:')) {
       return

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,6 +52,17 @@ process.on('warning', (warning) => {
   }
 })
 
+// Catch unhandled promise rejections in the main process
+process.on('unhandledRejection', (reason) => {
+  appLog.error(`Unhandled promise rejection: ${String(reason)}`)
+})
+
+// Catch uncaught exceptions in the main process — process state is corrupted, exit after logging
+process.on('uncaughtException', (error) => {
+  appLog.error(`Uncaught exception: ${String(error)}`)
+  process.exit(1)
+})
+
 // Privacy: Disable WebRTC to prevent IP leaks
 app.commandLine.appendSwitch('webrtc-ip-handling-policy', 'disable_non_proxied_udp')
 app.commandLine.appendSwitch('force-webrtc-ip-handling-policy')
@@ -210,11 +221,15 @@ function createWindow(): void {
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    const scheme = new URL(details.url).protocol
-    if (scheme !== 'https:' && scheme !== 'http:') {
-      return { action: 'deny' }
+    try {
+      const scheme = new URL(details.url).protocol
+      if (scheme !== 'https:' && scheme !== 'http:') {
+        return { action: 'deny' }
+      }
+      shell.openExternal(details.url)
+    } catch (err) {
+      appLog.error(`setWindowOpenHandler: invalid URL "${details.url}": ${String(err)}`)
     }
-    shell.openExternal(details.url)
     return { action: 'deny' }
   })
 
@@ -336,9 +351,11 @@ app.whenReady().then(() => {
   })
 })
 
-app.on('window-all-closed', async () => {
-  proxyManager.stop()
-  storageManager.stop()
+let isCleaningUp = false
+
+async function runCleanup(): Promise<void> {
+  if (isCleaningUp) return
+  isCleaningUp = true
 
   // Clear browsing data on exit if enabled
   const { clearOnExit } = getSetting('privacy')
@@ -360,6 +377,15 @@ app.on('window-all-closed', async () => {
       log.error(`Failed to clear browsing data: ${String(error)}`)
     }
   }
+
+  proxyManager.stop()
+  storageManager.stop()
+}
+
+app.on('window-all-closed', async () => {
+  if (isCleaningUp) return
+
+  await runCleanup()
 
   if (process.platform !== 'darwin') {
     app.quit()
@@ -390,14 +416,7 @@ app.on('before-quit', (event) => {
   // Cleanup history before quit — must await, so use Promise chain
   historyManager
     .onAppExit()
-    .then(() => {
-      proxyManager.stop()
-      storageManager.stop()
-      app.quit()
-    })
-    .catch(() => {
-      proxyManager.stop()
-      storageManager.stop()
-      app.quit()
-    })
+    .then(() => runCleanup())
+    .catch(() => runCleanup())
+    .finally(() => app.quit())
 })

--- a/src/main/ipc/handlers/storage.ts
+++ b/src/main/ipc/handlers/storage.ts
@@ -10,6 +10,22 @@ import { secureHandle, secureHandleWithEvent, handleSecure, storageLimiter, log 
 import { storageManager } from '../../storage/daemon'
 import { addBag, removeBag, listBags, pauseBag, getBagDetails } from '../../storage/bags'
 import { getMainWindow } from '../../windows/main'
+import { getDownloadPath } from '../../settings'
+
+/**
+ * Validate that a resolved path is within the configured download directory.
+ * Returns null if valid, or an error response object to short-circuit from handlers.
+ */
+function validatePathInDownloadDir(targetPath: string): { success: false; error: string } | null {
+  const downloadDir = path.resolve(getDownloadPath())
+  const resolved = path.resolve(targetPath)
+  // Ensure resolved path is inside the download directory (prevent path traversal)
+  if (!resolved.startsWith(downloadDir + path.sep) && resolved !== downloadDir) {
+    log.warn(`Blocked shell.openPath outside allowed directory: ${resolved}`)
+    return { success: false, error: 'Path outside allowed directory' }
+  }
+  return null
+}
 
 /**
  * Validate bag ID and return an error response if invalid.
@@ -102,7 +118,9 @@ export function registerStorageHandlers(): void {
       if (!details?.path) {
         return { success: false, error: 'Bag path not found' }
       }
-      const error = await shell.openPath(details.path)
+      const pathError = validatePathInDownloadDir(details.path)
+      if (pathError) return pathError
+      const error = await shell.openPath(path.resolve(details.path))
       return error ? { success: false, error } : { success: true }
     } catch (error) {
       return { success: false, error: (error as Error).message }
@@ -134,7 +152,10 @@ export function registerStorageHandlers(): void {
       if (!details?.path) {
         return { success: false, error: 'Bag path not found' }
       }
-      shell.showItemInFolder(path.join(details.path, sanitizedFileName))
+      const fullPath = path.join(details.path, sanitizedFileName)
+      const pathError = validatePathInDownloadDir(fullPath)
+      if (pathError) return pathError
+      shell.showItemInFolder(path.resolve(fullPath))
       return { success: true }
     } catch (error) {
       return { success: false, error: (error as Error).message }

--- a/src/main/windows/anti-fingerprinting.js
+++ b/src/main/windows/anti-fingerprinting.js
@@ -10,7 +10,7 @@
   protect('NavigatorSpoofing', () => {
     // Match HTTP User-Agent header for consistency
     Object.defineProperty(navigator, 'userAgent', {
-      get: () => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
+      get: () => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
       enumerable: true,
       configurable: true
     });
@@ -42,7 +42,7 @@
 
     // Derived properties for consistency
     Object.defineProperty(navigator, 'appVersion', {
-      get: () => '5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
+      get: () => '5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
       enumerable: true,
       configurable: true
     });

--- a/src/main/windows/tabs.ts
+++ b/src/main/windows/tabs.ts
@@ -635,7 +635,7 @@ function loadErrorPage(view: WebContentsView, errorMessage: string, failedUrl: s
       <div class="url">URL: ${failedUrl.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</div>
     </div>
     <div class="actions">
-      <button class="btn-primary" onclick="location.href=decodeURIComponent('${encodeURIComponent(failedUrl)}')">\u{1F504} Retry</button>
+      <button class="btn-primary" data-url="${encodeURIComponent(failedUrl)}" onclick="location.href=decodeURIComponent(this.dataset.url)">🔄 Retry</button>
       <button class="btn-secondary" onclick="history.back()">← Go Back</button>
     </div>
   </div>

--- a/src/renderer/src/components/settings/sections/AboutSection.tsx
+++ b/src/renderer/src/components/settings/sections/AboutSection.tsx
@@ -220,7 +220,7 @@ export const AboutSection = memo(function AboutSection() {
       <div className="mt-4 flex gap-3">
         <button
           className="flex-1 flex items-center justify-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium text-muted-foreground transition-all duration-200 hover:text-foreground bg-surface-hover border border-border-medium"
-          onClick={() => window.electron.navigate('http://github.com/example/ton-browser')}
+          onClick={() => window.electron.navigate('https://github.com/TONresistor/Tonnet-Browser')}
         >
           <ExternalLink className="h-4 w-4" />
           {t('about.github')}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -20,5 +20,6 @@ export const DEFAULT_BOOKMARKS = [
 ]
 
 // Privacy: Generic User-Agent without TONBrowser identifier
+// Chrome version matches Electron 39 (Chromium 134)
 export const USER_AGENT =
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36'
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36'


### PR DESCRIPTION
## Summary
Fixes the 8 highest-priority findings from the deep codebase scan.

### Security (3 fixes)
- **shell.openPath path traversal**: Validate daemon-provided path is within configured download directory before opening
- **Error page XSS**: Replace inline JS URL interpolation with safe `data-url` attribute pattern
- **shell.openExternal crash**: Add try/catch around `new URL()` parsing, deny on malformed URLs

### Stability (3 fixes)
- **Quit race condition**: Extract cleanup into guarded `runCleanup()` — prevents double `proxyManager.stop()` / `storageManager.stop()` when `window-all-closed` and `before-quit` fire simultaneously
- **History race condition**: Buffer `addEntry()` calls until `readyPromise` resolves — prevents entries being overwritten by late-loading persisted data
- **Unhandled errors**: Add `process.on('unhandledRejection')` + `process.on('uncaughtException')` with electron-log in main process

### Corrections (2 fixes)
- **GitHub URL**: Replace placeholder `example/ton-browser` with real `TONresistor/Tonnet-Browser` in About section
- **User-Agent**: Update spoofed Chrome version from 130 to 134 (matching Electron 39's actual Chromium)

## Test plan
- [x] Type-check passes (3 tsconfigs)
- [x] Lint passes (0 errors)
- [x] 370/370 tests pass
- [ ] Manual: verify error page Retry/Go Back buttons still work
- [ ] Manual: verify About > GitHub link opens correct repo
- [ ] Manual: verify `navigator.userAgent` shows Chrome/134