### PR TITLE
fix(filter): stop blocking a tonsite's own API as a third-party tracker

### DIFF
--- a/src/main/content-filter/README.md
+++ b/src/main/content-filter/README.md
@@ -16,6 +16,10 @@ Blocks ads, trackers, cryptominers, and malicious content on .ton sites.
 ```
 HTTP Request → onBeforeRequest → ContentFilterManager.isBlocked()
                                           ↓
+                                    [Whitelist check]
+                                          ↓
+                                 [First-party check] ──→ skip ads/trackers/annoyances
+                                          ↓
                                     [Check patterns]
                                           ↓
                                     Block or Allow
@@ -47,6 +51,24 @@ HTTP Request → onBeforeRequest → ContentFilterManager.isBlocked()
 - Intrusive overlays: `/modal/`, `/overlay/`, `/interstitial/`
 - Push notifications: `/notification/`, `/push-notify/`
 
+## First-party requests
+
+The patterns above are generic path heuristics written for third-party URLs, so they
+also fire on a site's own routes: `/api/analytics/...`, `/api/stats/...` and
+`/api/v1/track/...` are ordinary API paths, and cancelling them leaves a page loading
+its shell and then sitting empty with no visible error.
+
+So `isBlocked` takes the host of the top-level document, and skips the
+**third-party-only** categories — `ads`, `trackers`, `annoyances` — when the request
+is same-site.
+
+- **Miners and malware stay enforced first-party.** A compromised tonsite serving a
+  miner from its own origin is exactly the case worth blocking.
+- Subdomains count as same-site in both directions (`api.site.ton` ↔ `site.ton`), but
+  shared registry suffixes (`ton`, `t.me`, … — taken from `SUPPORTED_TLDS`) are
+  excluded from the parent match, or every tonsite would be first-party to every other.
+- Omitting the argument, or passing `null`, blocks exactly as before.
+
 ## Usage
 
 ```typescript
@@ -56,8 +78,8 @@ const { contentFilterManager } = registry
 // Sync configuration from user settings (enabled state, whitelist, category toggles)
 contentFilterManager.applySettings(getSetting('contentFiltering'))
 
-// Check if a URL should be blocked
-const blocked = contentFilterManager.isBlocked('http://site.ton/ads/banner.jpg', 'image')
+// Third argument is the top-level document's host; without it every rule applies.
+const blocked = contentFilterManager.isBlocked('http://site.ton/ads/banner.jpg', 'image', 'site.ton')
 ```
 
 ## Integration
@@ -65,14 +87,19 @@ const blocked = contentFilterManager.isBlocked('http://site.ton/ads/banner.jpg',
 The filter is integrated into `browser-view.ts` via `session.webRequest.onBeforeRequest`:
 
 ```typescript
-ses.webRequest.onBeforeRequest({ urls: ['http://*/*'] }, (details, callback) => {
-  if (contentFilterManager.isBlocked(details.url, details.resourceType)) {
+ses.webRequest.onBeforeRequest((details, callback) => {
+  if (contentFilterManager.isBlocked(details.url, details.resourceType, resolveFirstPartyHost(details, sessionHost))) {
     callback({ cancel: true }) // Block request
     return
   }
   callback({}) // Allow request
 })
 ```
+
+`resolveFirstPartyHost` reads `details.frame?.top?.url`, falling back to the isolated
+session's own domain when the frame is already gone (destroyed, or cross-process
+teardown). Sessions are created per domain in `tabs-session.ts`, which is where that
+fallback host comes from; bag sessions pass `null`, having no domain of their own.
 
 ## Testing
 

--- a/src/main/content-filter/__tests__/filter-manager.test.ts
+++ b/src/main/content-filter/__tests__/filter-manager.test.ts
@@ -145,6 +145,39 @@ describe('ContentFilterManager', () => {
     })
   })
 
+  describe('First-party requests', () => {
+    it('should not block a tonsite own analytics API as a tracker', () => {
+      const url = 'http://webdom.ton/api/analytics/statistics/price_history'
+
+      expect(filter.isBlocked(url, 'xhr')).toBe(true)
+      expect(filter.isBlocked(url, 'xhr', 'webdom.ton')).toBe(false)
+    })
+
+    it('should not block first-party ads/annoyance paths', () => {
+      expect(filter.isBlocked('http://site.ton/ads/banner.jpg', 'image', 'site.ton')).toBe(false)
+      expect(filter.isBlocked('http://site.ton/modal/dialog.js', 'script', 'site.ton')).toBe(false)
+    })
+
+    it('should treat subdomains of the visited site as first-party', () => {
+      expect(filter.isBlocked('http://api.webdom.ton/stats/x.json', 'xhr', 'webdom.ton')).toBe(false)
+      expect(filter.isBlocked('http://webdom.ton/stats/x.json', 'xhr', 'api.webdom.ton')).toBe(false)
+    })
+
+    it('should still block third-party trackers on a tonsite', () => {
+      expect(filter.isBlocked('http://tracker.other.ton/analytics/x.js', 'script', 'webdom.ton')).toBe(true)
+    })
+
+    it('should not treat a shared registry suffix as a common owner', () => {
+      expect(filter.isBlocked('http://other.ton/analytics/x.js', 'script', 'ton')).toBe(true)
+      expect(filter.isBlocked('http://someone.t.me/analytics/x.js', 'script', 't.me')).toBe(true)
+    })
+
+    it('should still block first-party miners and malware', () => {
+      expect(filter.isBlocked('http://site.ton/miner/cryptonight.js', 'script', 'site.ton')).toBe(true)
+      expect(filter.isBlocked('http://site.ton/malware/x.js', 'script', 'site.ton')).toBe(true)
+    })
+  })
+
   describe('Enable/disable', () => {
     it('should allow everything when disabled', () => {
       filter.applySettings({ ...ALL_ENABLED, enabled: false })

--- a/src/main/content-filter/filter-manager.ts
+++ b/src/main/content-filter/filter-manager.ts
@@ -6,12 +6,36 @@
 import { createLogger } from '../../shared/logger'
 const log = createLogger('filter')
 import type { ContentFilteringSettings } from '../../shared/types'
+import { SUPPORTED_TLDS } from '../../shared/tlds'
 
 export interface FilterRule {
   pattern: RegExp
   category: 'ads' | 'trackers' | 'miners' | 'malware' | 'annoyances'
   resourceTypes: Set<string>
   description: string
+}
+
+/**
+ * Categories that only ever describe third-party resources. The rules below are
+ * generic path heuristics, so on a first-party request they produce false
+ * positives against ordinary API routes (e.g. /api/analytics/statistics/...).
+ * Miners and malware stay enforced first-party: a compromised tonsite serving
+ * a miner from its own origin is exactly the case worth blocking.
+ */
+const THIRD_PARTY_ONLY_CATEGORIES: ReadonlySet<FilterRule['category']> = new Set(['ads', 'trackers', 'annoyances'])
+
+/** Registry suffixes that are never a site of their own, only a parent of one. */
+const PUBLIC_SUFFIXES = new Set(SUPPORTED_TLDS.map((tld) => tld.slice(1)))
+
+/** True when the request targets the site being browsed, or a subdomain of it. */
+function isFirstParty(requestHost: string, firstPartyHost: string): boolean {
+  if (!requestHost || !firstPartyHost) return false
+  if (requestHost === firstPartyHost) return true
+  // A shared registry suffix (ton, t.me) is not a common owner: every tonsite
+  // ends with it, so matching on it would make the whole network first-party.
+  if (requestHost.endsWith(`.${firstPartyHost}`)) return !PUBLIC_SUFFIXES.has(firstPartyHost)
+  if (firstPartyHost.endsWith(`.${requestHost}`)) return !PUBLIC_SUFFIXES.has(requestHost)
+  return false
 }
 
 export class ContentFilterManager {
@@ -147,9 +171,13 @@ export class ContentFilterManager {
   }
 
   /**
-   * Check if URL should be blocked
+   * Check if URL should be blocked.
+   *
+   * `firstPartyHost` is the host of the top-level document the request belongs
+   * to. When it is known, ad/tracker/annoyance rules are skipped for same-site
+   * requests so a tonsite's own API and assets are never mistaken for trackers.
    */
-  isBlocked(url: string, resourceType: string): boolean {
+  isBlocked(url: string, resourceType: string, firstPartyHost?: string | null): boolean {
     if (!this.enabled) {
       return false
     }
@@ -161,10 +189,17 @@ export class ContentFilterManager {
       return false
     }
 
+    const firstParty = !!firstPartyHost && isFirstParty(domain, firstPartyHost.toLowerCase())
+
     // Check each rule
     for (const rule of this.rules) {
       // Check if category is enabled
       if (!this.categoryEnabled[rule.category]) {
+        continue
+      }
+
+      // Third-party heuristics must not fire on the site's own resources
+      if (firstParty && THIRD_PARTY_ONLY_CATEGORIES.has(rule.category)) {
         continue
       }
 

--- a/src/main/windows/browser-view.ts
+++ b/src/main/windows/browser-view.ts
@@ -36,8 +36,30 @@ function installPermissionHandlers(ses: Electron.Session): void {
   ses.setDevicePermissionHandler(() => false)
 }
 
+/**
+ * Host of the top-level document a request belongs to, used to tell the site's
+ * own resources apart from third-party ones. Falls back to the session's domain
+ * when the frame is gone (destroyed or cross-process teardown).
+ */
+function resolveFirstPartyHost(details: Electron.OnBeforeRequestListenerDetails, sessionHost: string | null) {
+  try {
+    const topUrl = details.frame?.top?.url
+    if (topUrl) {
+      const host = new URL(topUrl).hostname
+      if (host) return host.toLowerCase()
+    }
+  } catch {
+    // Frame already destroyed — fall back to the session domain below.
+  }
+  return sessionHost
+}
+
 /** Cancel loopback (SSRF) and content-filtered requests. */
-function installRequestFilter(ses: Electron.Session, contentFilterManager: ContentFilterManager): void {
+function installRequestFilter(
+  ses: Electron.Session,
+  contentFilterManager: ContentFilterManager,
+  sessionHost: string | null
+): void {
   ses.webRequest.onBeforeRequest((details, callback) => {
     const { url, resourceType } = details
 
@@ -54,7 +76,7 @@ function installRequestFilter(ses: Electron.Session, contentFilterManager: Conte
     }
 
     // Check if request should be blocked by content filter
-    if (contentFilterManager.isBlocked(url, resourceType)) {
+    if (contentFilterManager.isBlocked(url, resourceType, resolveFirstPartyHost(details, sessionHost))) {
       callback({ cancel: true })
       return
     }
@@ -119,7 +141,8 @@ function installResponseSecurity(ses: Electron.Session): void {
 export async function createTonSession(
   deps: SessionDeps,
   proxyPort: number,
-  partitionName: string = SESSION_PARTITION
+  partitionName: string = SESSION_PARTITION,
+  sessionHost: string | null = null
 ) {
   const { contentFilterManager, paymentInterceptor } = deps
 
@@ -130,7 +153,7 @@ export async function createTonSession(
   ses.setUserAgent(USER_AGENT)
   // Sync content filter settings from user preferences before the request filter runs
   contentFilterManager.applySettings(getSetting('contentFiltering'))
-  installRequestFilter(ses, contentFilterManager)
+  installRequestFilter(ses, contentFilterManager, sessionHost)
   installHeaderPrivacy(ses, paymentInterceptor)
   // Register 402 payment interceptor on this session
   paymentInterceptor.registerOnSession(ses)

--- a/src/main/windows/tabs-session.ts
+++ b/src/main/windows/tabs-session.ts
@@ -87,7 +87,12 @@ export class TabSessionManager {
       return existing
     }
 
-    const session = await createTonSession(this.deps, proxyPort, partitionForIdentity(domain))
+    const session = await createTonSession(
+      this.deps,
+      proxyPort,
+      partitionForIdentity(domain),
+      domain.startsWith('bag:') ? null : domain.toLowerCase()
+    )
     this.domainSessions.set(domain, session)
     this.updateDomainActivity(domain)
     log.debug(`Created isolated session for domain: ${domain}`)


### PR DESCRIPTION
## The problem

The content filter cancels a tonsite's own API requests, so pages load their shell and then sit empty with no visible error.

On `webdom.ton`, every price-chart request goes to:

```
http://webdom.ton/api/analytics/statistics/price_history
```

which matches the `trackers` rule, because the path contains `/analytics/`:

```js
pattern: /\/(track|analytics|beacon|telemetry|stats|collect)[/_\-.]/i,
category: 'trackers',
resourceTypes: new Set(['script', 'xhr', 'image']),
```

`onBeforeRequest` cancels it, so the page only sees a failed fetch — nothing in the UI says the browser did this. In the logs it shows up only as:

```
Blocked [trackers] xhr: [URL]
```

The rules are generic path heuristics designed for third-party URLs, but `isBlocked()` had no notion of first-party, so they fire on the visited site's own routes too. `/analytics/` is just the case that bit here — `/api/stats/`, `/api/collect/` and `/api/v1/track/` are all equally ordinary API paths.

## The fix

Pass the top-level document's host into the filter and skip the third-party-only categories (`ads`, `trackers`, `annoyances`) when the request is same-site.

- **Miners and malware stay enforced first-party.** A compromised tonsite serving a miner from its own origin is exactly the case worth blocking.
- The first-party host comes from `details.frame?.top?.url`, falling back to the isolated session's own domain when the frame is gone.
- Subdomains count as same-site in both directions (`api.webdom.ton` ↔ `webdom.ton`), but shared registry suffixes (`ton`, `t.me`, taken from `SUPPORTED_TLDS`) are excluded from the parent match — otherwise every tonsite would be first-party to every other one.
- Third-party trackers on a tonsite are still blocked, and whitelist behaviour is unchanged.

## Testing

6 new cases in `filter-manager.test.ts` covering the `webdom.ton` repro, first-party ads/annoyances, subdomains in both directions, the shared-suffix exclusion, third-party still blocked, and miners/malware still blocked first-party.

`npm run validate` clean: type-check, architecture, theme tokens, lint, format, 1423 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
